### PR TITLE
Feat: 유저 서비스에 세션을 통한 검증 추가

### DIFF
--- a/src/main/java/com/example/newsfeed/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/newsfeed/global/common/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
     USER_NOT_FOUND("해당하는 유저를 찾을 수 없습니다.", NOT_FOUND),
     INVALID_PASSWORD("패스워드가 올바르지 않습니다.", BAD_REQUEST),
     PASSWORD_SAME_AS_OLD("이전 패스워드와 동일할 수 없습니다.", BAD_REQUEST),
+    USER_ACCESS_DENIED("사용자가 접근할 수 있는 권한이 없습니다.", FORBIDDEN),
 
 
     // 피드 관련 예외 코드

--- a/src/main/java/com/example/newsfeed/global/common/exception/GlobalControllerAdvice.java
+++ b/src/main/java/com/example/newsfeed/global/common/exception/GlobalControllerAdvice.java
@@ -3,7 +3,6 @@ package com.example.newsfeed.global.common.exception;
 import com.example.newsfeed.global.response.Response;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -11,13 +10,10 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import static com.example.newsfeed.global.common.exception.ErrorCode.SERVER_NOT_WORK;
 import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static jakarta.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
-import static org.springframework.http.HttpStatus.*;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 

--- a/src/main/java/com/example/newsfeed/user/application/converter/UserConverter.java
+++ b/src/main/java/com/example/newsfeed/user/application/converter/UserConverter.java
@@ -3,8 +3,7 @@ package com.example.newsfeed.user.application.converter;
 import com.example.newsfeed.user.dto.response.GetAllUsersResponseDto;
 import com.example.newsfeed.user.dto.response.GetUserResponseDto;
 import com.example.newsfeed.user.entity.User;
-
-import java.util.List;
+import org.springframework.data.domain.Page;
 
 public class UserConverter {
 
@@ -12,24 +11,10 @@ public class UserConverter {
     }
 
     public static GetUserResponseDto toResponse(User user) {
-        return GetUserResponseDto.of(
-            user.getId(),
-            user.getName(),
-            user.getProfileImage(),
-            user.getDescription(),
-            user.getFollowersCount(),
-            user.getFollowingsCount()
-        );
+        return GetUserResponseDto.of(user);
     }
 
-    public static List<GetAllUsersResponseDto> toResponse(List<User> users) {
-        return users.stream()
-            .map(user -> GetAllUsersResponseDto.of(
-                user.getId(),
-                user.getName(),
-                user.getProfileImage(),
-                user.getDescription()
-            ))
-            .toList();
+    public static Page<GetAllUsersResponseDto> toResponse(Page<User> users) {
+        return users.map(GetAllUsersResponseDto::of);
     }
 }

--- a/src/main/java/com/example/newsfeed/user/application/service/UserService.java
+++ b/src/main/java/com/example/newsfeed/user/application/service/UserService.java
@@ -3,6 +3,7 @@ package com.example.newsfeed.user.application.service;
 import com.example.newsfeed.global.common.exception.ErrorDetail;
 import com.example.newsfeed.user.application.converter.UserConverter;
 import com.example.newsfeed.user.dto.request.DeleteUserRequestDto;
+import com.example.newsfeed.user.dto.request.SearchUserRequestDto;
 import com.example.newsfeed.user.dto.request.UpdateUserPasswordRequestDto;
 import com.example.newsfeed.user.dto.request.UpdateUserRequestDto;
 import com.example.newsfeed.user.dto.response.GetAllUsersResponseDto;
@@ -10,9 +11,12 @@ import com.example.newsfeed.user.dto.response.GetUserResponseDto;
 import com.example.newsfeed.user.entity.User;
 import com.example.newsfeed.user.exception.InvalidPasswordException;
 import com.example.newsfeed.user.exception.PasswordSameAsOldException;
+import com.example.newsfeed.user.exception.UserAccessDeniedException;
 import com.example.newsfeed.user.exception.UserNotFoundException;
 import com.example.newsfeed.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,21 +32,28 @@ public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
 
+    // 유저 단건 조회
     @Transactional(readOnly = true)
     public GetUserResponseDto findUser(Long userId) {
         User findUser = findUserById(userId);
         return UserConverter.toResponse(findUser);
     }
 
+    // 키워드로 유저 전체 조회
     @Transactional(readOnly = true)
-    public List<GetAllUsersResponseDto> findUsers() {
-        List<User> users = userRepository.findAllUsers();
+    public Page<GetAllUsersResponseDto> findUsers(SearchUserRequestDto dto, Pageable pageable) {
+        Page<User> users = userRepository.findAllUsersByKeyword(dto.getKeyword(), pageable);
         return UserConverter.toResponse(users);
     }
 
+    // 유저 프로필 수정
     @Transactional
-    public Long updateUserProfile(Long userId, UpdateUserRequestDto dto) {
-        //TODO: 회원 인증 로직 구현 이후 로그인 유저와 저장된 유저 간의 검증 필요
+    public Long updateUserProfile(
+        Long userId,
+        UpdateUserRequestDto dto,
+        Long sessionUserId
+    ) {
+        checkUserPermission(userId, sessionUserId);
         User findUser = findUserById(userId);
 
         validatePassword(dto.getPassword(), findUser.getPassword());
@@ -60,9 +71,14 @@ public class UserService {
         return findUser.getId();
     }
 
+    // 유저 비밀번호 수정
     @Transactional
-    public Long updateUserPassword(Long userId, UpdateUserPasswordRequestDto dto) {
-        //TODO: 회원 인증 로직 구현 이후 로그인 유저와 저장된 유저 간의 검증 필요
+    public Long updateUserPassword(
+        Long userId,
+        UpdateUserPasswordRequestDto dto,
+        Long sessionUserId
+    ) {
+        checkUserPermission(userId, sessionUserId);
         User findUser = findUserById(userId);
 
         validatePassword(dto.getPassword(), findUser.getPassword());
@@ -77,20 +93,34 @@ public class UserService {
         return findUser.getId();
     }
 
+    // 유저 탈퇴
     @Transactional
-    public void deleteUser(Long userId, DeleteUserRequestDto dto) {
-        //TODO: 회원 인증 로직 구현 이후 로그인 유저와 저장된 유저 간의 검증 필요
+    public void deleteUser(
+        Long userId,
+        DeleteUserRequestDto dto,
+        Long sessionUserId
+    ) {
+        checkUserPermission(userId, sessionUserId);
         User findUser = findUserById(userId);
         validatePassword(dto.getPassword(), findUser.getPassword());
+        //TODO: 피드 및 댓글까지 전부 삭제해야 함
         userRepository.deleteUserById(userId);
     }
 
     public User findUserById(Long userId) {
-        //TODO: public으로 열지 않고 다른 도메인의 서비스에서도 호출하도록 로직을 바꿀 수 있는지 확인
         return userRepository.findUserById(userId)
             .orElseThrow(() -> new UserNotFoundException(List.of(
                 new ErrorDetail(USER_NOT_FOUND, null, USER_NOT_FOUND.getMessage())
             )));
+    }
+
+    // 로그인한 유저의 리소스 접근 허용 여부 확인
+    private void checkUserPermission(Long userId, Long sessionUserId) {
+        if (!userId.equals(sessionUserId)) {
+            throw new UserAccessDeniedException(List.of(
+                new ErrorDetail(USER_ACCESS_DENIED, null, USER_ACCESS_DENIED.getMessage())
+            ));
+        }
     }
 
     private void validatePassword(String inputPassword, String storedPassword) {

--- a/src/main/java/com/example/newsfeed/user/controller/UserController.java
+++ b/src/main/java/com/example/newsfeed/user/controller/UserController.java
@@ -3,15 +3,18 @@ package com.example.newsfeed.user.controller;
 import com.example.newsfeed.global.response.Response;
 import com.example.newsfeed.user.application.service.UserService;
 import com.example.newsfeed.user.dto.request.DeleteUserRequestDto;
+import com.example.newsfeed.user.dto.request.SearchUserRequestDto;
 import com.example.newsfeed.user.dto.request.UpdateUserPasswordRequestDto;
 import com.example.newsfeed.user.dto.request.UpdateUserRequestDto;
 import com.example.newsfeed.user.dto.response.GetAllUsersResponseDto;
 import com.example.newsfeed.user.dto.response.GetUserResponseDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.SortDefault;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/users")
@@ -23,39 +26,45 @@ public class UserController {
     @GetMapping("/{userId}")
     public Response<GetUserResponseDto> getUser(@PathVariable Long userId) {
         GetUserResponseDto getUserDto = userService.findUser(userId);
-        return Response.of(getUserDto);
+        return Response.of(getUserDto, "유저 단건 조회 성공");
     }
 
     @GetMapping
-    public Response<List<GetAllUsersResponseDto>> getUser() {
-        List<GetAllUsersResponseDto> getUsersDto = userService.findUsers();
-        return Response.of(getUsersDto);
+    public Response<Page<GetAllUsersResponseDto>> getUsers(
+        @Valid @RequestBody SearchUserRequestDto dto,
+        @SortDefault(sort = "name", direction = Sort.Direction.ASC) Pageable pageable
+    ) {
+        Page<GetAllUsersResponseDto> getUsersDto = userService.findUsers(dto, pageable);
+        return Response.of(getUsersDto, "유저 키워드 검색 성공");
     }
 
     @PatchMapping("/{userId}/profile")
     public Response<Long> updateUserProfile(
         @PathVariable Long userId,
-        @Valid @RequestBody UpdateUserRequestDto dto
+        @Valid @RequestBody UpdateUserRequestDto dto,
+        @SessionAttribute Long sessionUserId
     ) {
-        Long updatedUserId = userService.updateUserProfile(userId, dto);
-        return Response.of(updatedUserId);
+        Long updatedUserId = userService.updateUserProfile(userId, dto, sessionUserId);
+        return Response.of(updatedUserId, "프로필 수정 성공");
     }
 
     @PatchMapping("/{userId}/password")
     public Response<Long> updateUserPassword(
         @PathVariable Long userId,
-        @Valid @RequestBody UpdateUserPasswordRequestDto dto
+        @Valid @RequestBody UpdateUserPasswordRequestDto dto,
+        @SessionAttribute Long sessionUserId
     ) {
-        Long updatedUserId = userService.updateUserPassword(userId, dto);
-        return Response.of(updatedUserId);
+        Long updatedUserId = userService.updateUserPassword(userId, dto, sessionUserId);
+        return Response.of(updatedUserId, "패스워드 교체 성공");
     }
 
     @PostMapping("/{userId}/delete")
     public Response<Void> deleteUser(
         @PathVariable Long userId,
-        @Valid @RequestBody DeleteUserRequestDto dto
+        @Valid @RequestBody DeleteUserRequestDto dto,
+        @SessionAttribute Long sessionUserId
     ) {
-        userService.deleteUser(userId, dto);
-        return Response.empty();
+        userService.deleteUser(userId, dto, sessionUserId);
+        return Response.empty("회원 탈퇴 성공");
     }
 }

--- a/src/main/java/com/example/newsfeed/user/dto/request/SearchUserRequestDto.java
+++ b/src/main/java/com/example/newsfeed/user/dto/request/SearchUserRequestDto.java
@@ -1,0 +1,15 @@
+package com.example.newsfeed.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class SearchUserRequestDto {
+
+    @NotBlank
+    @Size(min = 2, message = "검색어는 두 글자보다 짧을 수 없습니다.")
+    private final String keyword;
+}

--- a/src/main/java/com/example/newsfeed/user/dto/response/GetAllUsersResponseDto.java
+++ b/src/main/java/com/example/newsfeed/user/dto/response/GetAllUsersResponseDto.java
@@ -1,5 +1,6 @@
 package com.example.newsfeed.user.dto.response;
 
+import com.example.newsfeed.user.entity.User;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -15,12 +16,12 @@ public class GetAllUsersResponseDto {
 
     private final String description;
 
-    public static GetAllUsersResponseDto of(
-        Long userId,
-        String name,
-        String profileImage,
-        String description
-    ) {
-        return new GetAllUsersResponseDto(userId, name, profileImage, description);
+    public static GetAllUsersResponseDto of(User user) {
+        return new GetAllUsersResponseDto(
+            user.getId(),
+            user.getName(),
+            user.getProfileImage(),
+            user.getDescription()
+        );
     }
 }

--- a/src/main/java/com/example/newsfeed/user/dto/response/GetUserResponseDto.java
+++ b/src/main/java/com/example/newsfeed/user/dto/response/GetUserResponseDto.java
@@ -1,5 +1,6 @@
 package com.example.newsfeed.user.dto.response;
 
+import com.example.newsfeed.user.entity.User;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -19,15 +20,15 @@ public class GetUserResponseDto {
 
     private final Long followingsCount;
 
-    public static GetUserResponseDto of(
-        Long userId,
-        String name,
-        String profileImage,
-        String description,
-        Long followersCount,
-        Long followingsCount
-    ) {
-        return new GetUserResponseDto(userId, name, profileImage, description, followersCount, followingsCount);
+    public static GetUserResponseDto of(User user) {
+        return new GetUserResponseDto(
+            user.getId(),
+            user.getName(),
+            user.getProfileImage(),
+            user.getDescription(),
+            user.getFollowersCount(),
+            user.getFollowingsCount()
+        );
     }
 
 }

--- a/src/main/java/com/example/newsfeed/user/exception/UserAccessDeniedException.java
+++ b/src/main/java/com/example/newsfeed/user/exception/UserAccessDeniedException.java
@@ -1,0 +1,13 @@
+package com.example.newsfeed.user.exception;
+
+import com.example.newsfeed.global.common.exception.BaseException;
+import com.example.newsfeed.global.common.exception.ErrorDetail;
+
+import java.util.List;
+
+public class UserAccessDeniedException extends BaseException {
+
+    public UserAccessDeniedException(List<ErrorDetail> errorDetails) {
+        super(errorDetails);
+    }
+}

--- a/src/main/java/com/example/newsfeed/user/repository/UserRepository.java
+++ b/src/main/java/com/example/newsfeed/user/repository/UserRepository.java
@@ -1,12 +1,13 @@
 package com.example.newsfeed.user.repository;
 
 import com.example.newsfeed.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -14,8 +15,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query(value = "select u from User u where u.id = :userId")
     Optional<User> findUserById(Long userId);
 
-    @Query(value = "select u from User u where u.deletedAt = null")
-    List<User> findAllUsers();
+    @Query(value = "select u from User u where u.name like concat('%', :keyword, '%') and u.deletedAt is null")
+    Page<User> findAllUsersByKeyword(String keyword, Pageable pageable);
 
     @Modifying
     @Query(value = "update User u set u.deletedAt = current_timestamp where u.id = :userId")


### PR DESCRIPTION
## 📌 What is this PR ?

유저 서비스에 세션을 통한 검증 추가

<br/>

## 🔎 Additions
- `UserService`에 주석 추가
- 로그인한 유저의 리소스 접근 허용 여부 확인을 위한 `checkUserPermission` 추가 및 예외 처리 추가
- `UserController`에 session에 저장된 값을 가져오는 `@SessionAttribute` 추가
- `Response.of()` 응답 시 메시지를 전부 포함하도록 변경하기 위해 모든 응답에 메시지 추가

## 🔎 Changes
- 유저 전체 조회를 최소 두 글자 이상의 `keyword`를 받아서 검색 후 가나다순으로 정렬해서 반환하도록 변경하고, 필요한 DTO 생성, 서비스 로직 변경, repository jpql 변경
- `GlobalControllerAdvice` 사용하지 않는 import 제거
- `GetUserResponseDto` 및 `GetAllUsersResponseDto` 정적 메서드의 파라미터를 개별 필드로 받는 것이 아닌 `User` 엔티티로 받도록 변경

<br/>

## ✅ Test Checklist
- [X] PR 양식에 맞춰서 작성했나요?
- [X] Reviewers를 등록했나요?
- [X] Assignees를 등록했나요?
- [X] Labels를 등록했나요?
