### PR TITLE
Feat: 파일 서비스 추가

### DIFF
--- a/src/main/java/com/example/newsfeed/global/common/constant/ImageUrlConst.java
+++ b/src/main/java/com/example/newsfeed/global/common/constant/ImageUrlConst.java
@@ -1,0 +1,9 @@
+package com.example.newsfeed.global.common.constant;
+
+public class ImageUrlConst {
+
+    private ImageUrlConst() {
+    }
+
+    public static final String IMAGE_URL = "imageUrl";
+}

--- a/src/main/java/com/example/newsfeed/global/common/file/FileType.java
+++ b/src/main/java/com/example/newsfeed/global/common/file/FileType.java
@@ -1,0 +1,14 @@
+package com.example.newsfeed.global.common.file;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum FileType {
+
+    PROFILE("profile"),
+    FEEDS("feeds");
+
+    private final String type;
+}

--- a/src/main/java/com/example/newsfeed/global/common/file/controller/FileController.java
+++ b/src/main/java/com/example/newsfeed/global/common/file/controller/FileController.java
@@ -6,10 +6,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static com.example.newsfeed.global.common.constant.ImageUrlConst.IMAGE_URL;
+import static com.example.newsfeed.global.common.constant.SessionConst.LOGIN_USER;
 
 @RestController
 @RequestMapping("/files")
@@ -18,15 +21,31 @@ public class FileController {
 
     private final FileService fileService;
 
-    @PostMapping("/image")
+    @PostMapping
     public Response<Map<String, String>> uploadImage(
         @RequestParam String type,
         @RequestParam MultipartFile file,
-        @SessionAttribute Long sessionUserId
+        @SessionAttribute(LOGIN_USER) Long sessionUserId
     ) {
         String imageUrl = fileService.uploadImage(type, file, sessionUserId);
         Map<String, String> response = new HashMap<>();
         response.put(IMAGE_URL, imageUrl);
         return Response.of(response, "이미지 저장 완료");
+    }
+
+    @PostMapping("/multiple")
+    public Response<Map<String, List<String>>> uploadImage(
+        @RequestParam("type") String type,
+        @RequestParam("files") List<MultipartFile> files,
+        @SessionAttribute(LOGIN_USER) Long sessionUserId
+    ) {
+        List<String> imageUrls = new ArrayList<>();
+        for (MultipartFile file : files) {
+            String imageUrl = fileService.uploadImage(type, file, sessionUserId);
+            imageUrls.add(imageUrl);
+        }
+        Map<String, List<String>> response = new HashMap<>();
+        response.put(IMAGE_URL, imageUrls);
+        return Response.of(response, "다중 이미지 저장 완료");
     }
 }

--- a/src/main/java/com/example/newsfeed/global/common/file/controller/FileController.java
+++ b/src/main/java/com/example/newsfeed/global/common/file/controller/FileController.java
@@ -1,0 +1,32 @@
+package com.example.newsfeed.global.common.file.controller;
+
+import com.example.newsfeed.global.common.file.service.FileService;
+import com.example.newsfeed.global.response.Response;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.example.newsfeed.global.common.constant.ImageUrlConst.IMAGE_URL;
+
+@RestController
+@RequestMapping("/files")
+@RequiredArgsConstructor
+public class FileController {
+
+    private final FileService fileService;
+
+    @PostMapping("/image")
+    public Response<Map<String, String>> uploadImage(
+        @RequestParam String type,
+        @RequestParam MultipartFile file,
+        @SessionAttribute Long sessionUserId
+    ) {
+        String imageUrl = fileService.uploadImage(type, file, sessionUserId);
+        Map<String, String> response = new HashMap<>();
+        response.put(IMAGE_URL, imageUrl);
+        return Response.of(response, "이미지 저장 완료");
+    }
+}

--- a/src/main/java/com/example/newsfeed/global/common/file/exception/FileUploadFailedException.java
+++ b/src/main/java/com/example/newsfeed/global/common/file/exception/FileUploadFailedException.java
@@ -1,0 +1,13 @@
+package com.example.newsfeed.global.common.file.exception;
+
+import com.example.newsfeed.global.common.exception.BaseException;
+import com.example.newsfeed.global.common.exception.ErrorDetail;
+
+import java.util.List;
+
+public class FileUploadFailedException extends BaseException {
+
+    public FileUploadFailedException(List<ErrorDetail> errorDetails) {
+        super(errorDetails);
+    }
+}

--- a/src/main/java/com/example/newsfeed/global/common/file/service/FileService.java
+++ b/src/main/java/com/example/newsfeed/global/common/file/service/FileService.java
@@ -1,0 +1,9 @@
+package com.example.newsfeed.global.common.file.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface FileService {
+
+    // type 정보에 따라 profile 또는 feed로 분리
+    String uploadImage(String type, MultipartFile file, Long sessionUserId);
+}

--- a/src/main/java/com/example/newsfeed/global/common/file/service/LocalFileService.java
+++ b/src/main/java/com/example/newsfeed/global/common/file/service/LocalFileService.java
@@ -1,0 +1,86 @@
+package com.example.newsfeed.global.common.file.service;
+
+import com.example.newsfeed.global.common.exception.ErrorDetail;
+import com.example.newsfeed.global.common.file.exception.FileUploadFailedException;
+import com.example.newsfeed.user.application.service.UserService;
+import com.example.newsfeed.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.DigestUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+import static com.example.newsfeed.global.common.exception.ErrorCode.UPLOAD_FAILED;
+import static com.example.newsfeed.global.common.file.FileType.FEEDS;
+import static com.example.newsfeed.global.common.file.FileType.PROFILE;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+
+@Service
+@RequiredArgsConstructor
+public class LocalFileService implements FileService {
+
+    @Value("${base.dir}")
+    private String baseDir;
+
+    private final UserService userService;
+
+    @Override
+    public String uploadImage(String type, MultipartFile file, Long sessionUserId) {
+        User getSessionUser = userService.findUserById(sessionUserId);
+
+        // 이메일 암호화
+        String convertEmail = DigestUtils.md5DigestAsHex(getSessionUser.getEmail().getBytes());
+
+        // 업로드하는 타입에 따라 하위 폴더명 설정
+        String subDirectory;
+        if (PROFILE.getType().equalsIgnoreCase(type)) {
+            subDirectory = "profile";
+        } else if (FEEDS.getType().equalsIgnoreCase(type)) {
+            subDirectory = "feeds";
+        } else {
+            subDirectory = "others";
+        }
+
+        // 업로드하는 시간을 가져와서 연/월/일로 변환
+        String datePath = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy/MM/dd"));
+
+        // 파일 업로드 디렉토리
+        String uploadDir = baseDir + "/" + convertEmail + "/" + subDirectory + "/" + datePath;
+
+        // `UUID_원본파일`로 최종 파일 이름을 만들기 위함
+        // file의 이름을 경로에 안전하게 변환
+        String fileName = UUID.randomUUID() + "_" + StringUtils.cleanPath(Objects.requireNonNull(file.getOriginalFilename()));
+
+        try {
+            // 파일 저장 경로 가져오기
+            Path uploadPath = Paths.get(uploadDir);
+            if (!Files.exists(uploadPath)) {
+                // 경로에 폴더가 없을 경우 생성
+                Files.createDirectories(uploadPath);
+            }
+
+            // uploadPath에 fileName을 더한 최종 경로를 반환
+            Path filePath = uploadPath.resolve(fileName);
+            
+            // file.getInputStream()으로 읽은 뒤 filePath에 동일한 파일이 있을 경우 덮어쓰기 후 저장
+            Files.copy(file.getInputStream(), filePath, REPLACE_EXISTING);
+
+            return "/files/" + convertEmail + "/" + subDirectory + "/" + datePath + "/" + fileName;
+        } catch (IOException ioe) {
+            throw new FileUploadFailedException(List.of(
+                new ErrorDetail(UPLOAD_FAILED, "file", UPLOAD_FAILED.getMessage())
+            ));
+        }
+    }
+}

--- a/src/main/java/com/example/newsfeed/global/config/FileServiceConfig.java
+++ b/src/main/java/com/example/newsfeed/global/config/FileServiceConfig.java
@@ -1,0 +1,16 @@
+package com.example.newsfeed.global.config;
+
+import com.example.newsfeed.global.common.file.service.FileService;
+import com.example.newsfeed.global.common.file.service.LocalFileService;
+import com.example.newsfeed.user.application.service.UserService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FileServiceConfig {
+
+    @Bean
+    public FileService fileService(UserService userService) {
+        return new LocalFileService(userService);
+    }
+}

--- a/src/main/java/com/example/newsfeed/global/config/StaticResourceConfig.java
+++ b/src/main/java/com/example/newsfeed/global/config/StaticResourceConfig.java
@@ -1,0 +1,19 @@
+package com.example.newsfeed.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class StaticResourceConfig implements WebMvcConfigurer {
+
+    @Value("${base.dir}")
+    private String baseDir;
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/files/**")
+            .addResourceLocations("file:///" + baseDir);
+    }
+}


### PR DESCRIPTION
## 📌 What is this PR ?

파일 서비스 추가

<br/>

## 🔎 Additions

- 공통 이미지 업로드를 위한 `FileController` 생성하여 공통 API로 관리
- `FileType`을 통해 각 타입을 열거형 상수로 사용해서 실수 발생 가능성을 줄임
- 이후 다른 서비스 사용 가능성(확장성)을 위해 `FileService`를 추상화하여 사용
- 로컬 저장소에 파일을 저장하는 `LocalFileService` 구현
- `ImageUrlConst`를 사용하여 일관성과 유지보수성 향상
- 파일 업로드 실패 시 사용할 커스텀 예외인 `FileUploadFailedException` 생성

<br/>

## ✅ Test Checklist
- [X] PR 양식에 맞춰서 작성했나요?
- [X] Reviewers를 등록했나요?
- [X] Assignees를 등록했나요?
- [X] Labels를 등록했나요?
