### PR TITLE
Feat: 유저 탈퇴 시 연관된 내용 삭제 로직 추가

### DIFF
--- a/src/main/java/com/example/newsfeed/follow/application/service/FollowService.java
+++ b/src/main/java/com/example/newsfeed/follow/application/service/FollowService.java
@@ -52,14 +52,26 @@ public class FollowService {
                     return true; // 팔로우 처리
                 });
     }
+
     // 특정 사용자가 팔로우한 ID 목록 조회
     @Transactional(readOnly = true)
     public List<Long> findFollowingIdsByUserId(Long userId) {
         return followRepository.findFollowingIdsByUserId(userId);
     }
+
     // 특정 사용자를 팔로잉한 ID 목록 조회
     @Transactional(readOnly = true)
     public List<Long> findFollowerIdsByUserId(Long userId) {
         return followRepository.findFollowerIdsByUserId(userId);
+    }
+
+    @Transactional
+    public void decreaseFollowersOfFollowedUsers(Long sessionUserId) {
+        followRepository.decreaseFollowersOfFollowedUsers(sessionUserId);
+    }
+
+    @Transactional
+    public void decreaseFollowingsOfFollowers(Long sessionUserId) {
+        followRepository.decreaseFollowingsOfFollowers(sessionUserId);
     }
 }

--- a/src/main/java/com/example/newsfeed/follow/repository/FollowRepository.java
+++ b/src/main/java/com/example/newsfeed/follow/repository/FollowRepository.java
@@ -3,6 +3,7 @@ package com.example.newsfeed.follow.repository;
 import com.example.newsfeed.follow.entity.Follow;
 import com.example.newsfeed.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -16,8 +17,22 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
    @Query("SELECT f.following.id FROM Follow f" +
            " WHERE f.follower.id = :userId AND f.following.deletedAt IS NULL")
    List<Long> findFollowingIdsByUserId(@Param("userId") Long userId);
+
    // 팔로워들의 ID 조회
    @Query("SELECT f.follower.id FROM Follow f" +
            " WHERE f.following.id = :userId AND f.follower.deletedAt IS NULL")
    List<Long> findFollowerIdsByUserId(@Param("userId") Long userId);
+
+   // 삭제되는 유저가 팔로우하고 있던 대상 유저의 FollowersCount를 감소
+   // 반환 시 업데이트된 행의 수를 반환함 -> 반환 타입(int, long) 설정 시 검증이나 로깅 가능
+   @Modifying
+   @Query("update User u set u.followersCount = u.followersCount - 1 " +
+       "where u.id in (select f.following.id from Follow f where f.follower.id = :userId)")
+   void decreaseFollowersOfFollowedUsers(@Param("userId") Long userId);
+
+   // 삭제되는 유저를 팔로잉하고 있던 대상 유저의 FollowingsCount를 감소
+   @Modifying
+   @Query("update User u set u.followingsCount = u.followingsCount - 1 " +
+       "where u.id in (select f.follower.id from Follow f where f.following.id = :userId)")
+   void decreaseFollowingsOfFollowers(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/newsfeed/global/common/constant/ImageUrlConst.java
+++ b/src/main/java/com/example/newsfeed/global/common/constant/ImageUrlConst.java
@@ -2,8 +2,10 @@ package com.example.newsfeed.global.common.constant;
 
 public class ImageUrlConst {
 
+    public static final String IMAGE_URL = "imageUrl";
+
+    public static final String DEFAULT_PROFILE_IMAGE_PATH = "/files/default/profile.jpg";
+
     private ImageUrlConst() {
     }
-
-    public static final String IMAGE_URL = "imageUrl";
 }

--- a/src/main/java/com/example/newsfeed/global/common/file/FileType.java
+++ b/src/main/java/com/example/newsfeed/global/common/file/FileType.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum FileType {
 
     PROFILE("profile"),
-    FEEDS("feeds");
+    FEEDS("feeds"),
+    DEFAULT("default");
 
     private final String type;
 }

--- a/src/main/java/com/example/newsfeed/global/common/file/service/LocalFileService.java
+++ b/src/main/java/com/example/newsfeed/global/common/file/service/LocalFileService.java
@@ -21,9 +21,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
+import static com.example.newsfeed.global.common.constant.ImageUrlConst.DEFAULT_PROFILE_IMAGE_PATH;
 import static com.example.newsfeed.global.common.exception.ErrorCode.UPLOAD_FAILED;
-import static com.example.newsfeed.global.common.file.FileType.FEEDS;
-import static com.example.newsfeed.global.common.file.FileType.PROFILE;
+import static com.example.newsfeed.global.common.file.FileType.*;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 @Service
@@ -38,6 +38,11 @@ public class LocalFileService implements FileService {
     @Override
     public String uploadImage(String type, MultipartFile file, Long sessionUserId) {
         User getSessionUser = userService.findUserById(sessionUserId);
+
+        // 프로필 이미지를 기본 이미지로 변경
+        if (DEFAULT.getType().equalsIgnoreCase(type) && file.isEmpty()) {
+            return DEFAULT_PROFILE_IMAGE_PATH;
+        }
 
         // 이메일 암호화
         String convertEmail = DigestUtils.md5DigestAsHex(getSessionUser.getEmail().getBytes());

--- a/src/main/java/com/example/newsfeed/user/application/service/UserService.java
+++ b/src/main/java/com/example/newsfeed/user/application/service/UserService.java
@@ -1,5 +1,8 @@
 package com.example.newsfeed.user.application.service;
 
+import com.example.newsfeed.comment.application.service.CommentService;
+import com.example.newsfeed.feed.application.service.FeedService;
+import com.example.newsfeed.follow.application.service.FollowService;
 import com.example.newsfeed.global.common.exception.ErrorDetail;
 import com.example.newsfeed.user.application.converter.UserConverter;
 import com.example.newsfeed.user.dto.request.DeleteUserRequestDto;
@@ -31,6 +34,9 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final FeedService feedService;
+    private final CommentService commentService;
+    private final FollowService followService;
 
     // 유저 단건 조회
     @Transactional(readOnly = true)
@@ -66,7 +72,9 @@ public class UserService {
             findUser.updateDescription(dto.getDescription());
         }
 
-        //TODO: 파일 저장 및 로드는 완성되면 추가해야 함
+        if (dto.getImagePath() != null) {
+            findUser.updateProfileImage(dto.getImagePath());
+        }
 
         return findUser.getId();
     }
@@ -103,7 +111,16 @@ public class UserService {
         checkUserPermission(userId, sessionUserId);
         User findUser = findUserById(userId);
         validatePassword(dto.getPassword(), findUser.getPassword());
-        //TODO: 피드 및 댓글까지 전부 삭제해야 함
+
+        // 탈퇴 유저가 팔로우한 유저들의 팔로워 수를 줄임
+        followService.decreaseFollowersOfFollowedUsers(findUser.getId());
+
+        // 탈퇴 유저를 팔로워한 유저들의 팔로잉 수를 줄임
+        followService.decreaseFollowingsOfFollowers(findUser.getId());
+        
+        // 탈퇴하려는 유저와 관련된 댓글과 피드 모두 삭제
+        commentService.deleteCommentsByUserId(findUser.getId());
+        feedService.deleteFeedsByUserId(findUser.getId());
         userRepository.deleteUserById(userId);
     }
 

--- a/src/main/java/com/example/newsfeed/user/controller/UserController.java
+++ b/src/main/java/com/example/newsfeed/user/controller/UserController.java
@@ -16,6 +16,8 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.SortDefault;
 import org.springframework.web.bind.annotation.*;
 
+import static com.example.newsfeed.global.common.constant.SessionConst.LOGIN_USER;
+
 @RestController
 @RequestMapping("/users")
 @RequiredArgsConstructor
@@ -42,7 +44,7 @@ public class UserController {
     public Response<Long> updateUserProfile(
         @PathVariable Long userId,
         @Valid @RequestBody UpdateUserRequestDto dto,
-        @SessionAttribute Long sessionUserId
+        @SessionAttribute(LOGIN_USER) Long sessionUserId
     ) {
         Long updatedUserId = userService.updateUserProfile(userId, dto, sessionUserId);
         return Response.of(updatedUserId, "프로필 수정 성공");
@@ -52,7 +54,7 @@ public class UserController {
     public Response<Long> updateUserPassword(
         @PathVariable Long userId,
         @Valid @RequestBody UpdateUserPasswordRequestDto dto,
-        @SessionAttribute Long sessionUserId
+        @SessionAttribute(LOGIN_USER) Long sessionUserId
     ) {
         Long updatedUserId = userService.updateUserPassword(userId, dto, sessionUserId);
         return Response.of(updatedUserId, "패스워드 교체 성공");
@@ -62,7 +64,7 @@ public class UserController {
     public Response<Void> deleteUser(
         @PathVariable Long userId,
         @Valid @RequestBody DeleteUserRequestDto dto,
-        @SessionAttribute Long sessionUserId
+        @SessionAttribute(LOGIN_USER) Long sessionUserId
     ) {
         userService.deleteUser(userId, dto, sessionUserId);
         return Response.empty("회원 탈퇴 성공");

--- a/src/main/java/com/example/newsfeed/user/dto/request/UpdateUserRequestDto.java
+++ b/src/main/java/com/example/newsfeed/user/dto/request/UpdateUserRequestDto.java
@@ -6,7 +6,6 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.multipart.MultipartFile;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
@@ -21,7 +20,7 @@ public class UpdateUserRequestDto {
 
     @Nullable
     @JsonInclude(NON_NULL)
-    private final MultipartFile profileImage;
+    private final String imagePath;
 
     @Nullable
     @JsonInclude(NON_NULL)

--- a/src/main/java/com/example/newsfeed/user/entity/User.java
+++ b/src/main/java/com/example/newsfeed/user/entity/User.java
@@ -5,19 +5,20 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 import java.time.LocalDateTime;
 
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = PROTECTED)
 @Table(name = "users")
 public class User extends BaseTimeEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "user_id")
+    @GeneratedValue(strategy = IDENTITY)
     private Long id;
 
     @Column(nullable = false, unique = true)


### PR DESCRIPTION
## 📌 What is this PR ?

유저 탈퇴 시 연관된 내용 삭제 로직 추가

<br/>

## 🔎 Additions
- 유저 탈퇴 시 탈퇴한 유저가 팔로우/팔로잉 중인 유저들의 각 `followingsCount` & `followersCount`를 줄이기 위해 `FollowRepository`에 JPQL 정의 및 `FollowService`에 메서드 구현
- `UserService`에 유저 탈퇴 시 유저는 soft-delete 되고 나머진 hard-delete 되도록 메서드 구현
- `UserController`에서 `@SessionAttribute` 설정 이후 값을 넣지 않은 곳에 `LOGIN_USER` 추가

## 🔎 Changes
- 유저 프로필 수정 시 기본 이미지 설정을 위해 `FileType`에 상수(`DEFAULT`) 정의 후 `LocalFileService`에서 조건 충족 시 `ImageUrlConst`에 정의한 `DEFAULT_PROFILE_IMAGE_PATH`를 바로 반환하도록 수정
- `UpdateUserRequestDto`에 저장한 프로필 사진의 String path 값을 받을 수 있도록 필드 수정
- `User` 엔티티의 기본 생성자를 JPA만 사용할 수 있게 PROTECTED로 접근 제한 설정 후 가독성을 위해 static import 처리함

<br/>

## ✅ Test Checklist
- [X] PR 양식에 맞춰서 작성했나요?
- [X] Reviewers를 등록했나요?
- [X] Assignees를 등록했나요?
- [X] Labels를 등록했나요?