### PR TITLE
Refactor: 회원가입 시 기본 이미지 저장

### DIFF
--- a/src/main/java/com/example/newsfeed/auth/application/service/AuthService.java
+++ b/src/main/java/com/example/newsfeed/auth/application/service/AuthService.java
@@ -2,18 +2,16 @@ package com.example.newsfeed.auth.application.service;
 
 import com.example.newsfeed.auth.application.converter.AuthConverter;
 import com.example.newsfeed.auth.dto.request.LoginUserRequestDto;
+import com.example.newsfeed.auth.dto.request.SignUpUserRequestDto;
 import com.example.newsfeed.auth.dto.response.LoginUserResponseDto;
 import com.example.newsfeed.auth.dto.response.SignUpUserResponseDto;
 import com.example.newsfeed.auth.exception.UserEmailDuplicationExcepion;
 import com.example.newsfeed.auth.exception.UserNameDuplicationException;
 import com.example.newsfeed.auth.repository.AuthRepository;
 import com.example.newsfeed.global.common.exception.ErrorDetail;
-import com.example.newsfeed.auth.dto.request.SignUpUserRequestDto;
 import com.example.newsfeed.user.entity.User;
 import com.example.newsfeed.user.exception.InvalidPasswordException;
 import com.example.newsfeed.user.exception.UserNotFoundException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -21,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import static com.example.newsfeed.global.common.constant.ImageUrlConst.DEFAULT_PROFILE_IMAGE_PATH;
 import static com.example.newsfeed.global.common.exception.ErrorCode.*;
 
 @RequiredArgsConstructor
@@ -35,11 +34,12 @@ public class AuthService {
         isUserNameDuplication(dto.getName());
 
         User createUser = authRepository.save(
-                User.builder()
-                        .email(dto.getEmail())
-                        .password(passwordEncoder.encode(dto.getPassword()))
-                        .name(dto.getName())
-                        .build()
+            User.builder()
+                .email(dto.getEmail())
+                .password(passwordEncoder.encode(dto.getPassword()))
+                .name(dto.getName())
+                .profileImage(DEFAULT_PROFILE_IMAGE_PATH)
+                .build()
         );
 
         return AuthConverter.toSignUpResponse(createUser);
@@ -47,18 +47,18 @@ public class AuthService {
 
     @Transactional(readOnly = true)
     public LoginUserResponseDto loginUser(LoginUserRequestDto dto) {
-        User findUser = authRepository.findByEmail(dto.getEmail())
-                .orElseThrow(() ->
-                        new UserNotFoundException(List.of(
-                                new ErrorDetail(
-                                        USER_NOT_FOUND, null, USER_NOT_FOUND.getMessage()
-                                )
-                        ))
-                );
+        User findUser = authRepository.findUserByEmailAndDeletedAtIsNull(dto.getEmail())
+            .orElseThrow(() ->
+                new UserNotFoundException(List.of(
+                    new ErrorDetail(
+                        USER_NOT_FOUND, null, USER_NOT_FOUND.getMessage()
+                    )
+                ))
+            );
 
-        if(!passwordEncoder.matches(dto.getPassword(), findUser.getPassword())) {
+        if (!passwordEncoder.matches(dto.getPassword(), findUser.getPassword())) {
             throw new InvalidPasswordException(List.of(
-                    new ErrorDetail(INVALID_PASSWORD, null, INVALID_PASSWORD.getMessage())
+                new ErrorDetail(INVALID_PASSWORD, null, INVALID_PASSWORD.getMessage())
             ));
         }
 
@@ -67,22 +67,22 @@ public class AuthService {
 
     // 유저 이메일 중복 검사 메서드
     private void isUserEmailDuplication(String email) {
-        if(authRepository.existsByEmail(email)) {
+        if (authRepository.existsByEmail(email)) {
             throw new UserEmailDuplicationExcepion(List.of(
-                    new ErrorDetail(
-                            USER_EMAIL_DUPLICATION, "email", USER_EMAIL_DUPLICATION.getMessage()
-                    )
+                new ErrorDetail(
+                    USER_EMAIL_DUPLICATION, "email", USER_EMAIL_DUPLICATION.getMessage()
+                )
             ));
         }
     }
 
     // 유저 이름 중복 검사 메서드
     private void isUserNameDuplication(String name) {
-        if(authRepository.existsByName(name)) {
+        if (authRepository.existsByName(name)) {
             throw new UserNameDuplicationException(List.of(
-               new ErrorDetail(
-                       USER_NAME_DUPLICATION, "name", USER_NAME_DUPLICATION.getMessage()
-               )
+                new ErrorDetail(
+                    USER_NAME_DUPLICATION, "name", USER_NAME_DUPLICATION.getMessage()
+                )
             ));
         }
     }

--- a/src/main/java/com/example/newsfeed/auth/controller/AuthController.java
+++ b/src/main/java/com/example/newsfeed/auth/controller/AuthController.java
@@ -16,9 +16,10 @@ import org.springframework.web.bind.annotation.RestController;
 
 import static com.example.newsfeed.global.common.constant.SessionConst.LOGIN_USER;
 
-@RequiredArgsConstructor
 @RestController
+@RequiredArgsConstructor
 public class AuthController {
+
     private final AuthService authService;
 
     @PostMapping("/signup")

--- a/src/main/java/com/example/newsfeed/auth/repository/AuthRepository.java
+++ b/src/main/java/com/example/newsfeed/auth/repository/AuthRepository.java
@@ -2,6 +2,7 @@ package com.example.newsfeed.auth.repository;
 
 import com.example.newsfeed.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
@@ -12,5 +13,6 @@ public interface AuthRepository extends JpaRepository<User, Long> {
 
     boolean existsByName(String name);
 
-    Optional<User> findByEmail(String email);
+    @Query("select u from User u where u.email = :email and u.deletedAt is null")
+    Optional<User> findUserByEmailAndDeletedAtIsNull(String email);
 }

--- a/src/main/java/com/example/newsfeed/follow/application/service/FollowService.java
+++ b/src/main/java/com/example/newsfeed/follow/application/service/FollowService.java
@@ -7,6 +7,7 @@ import com.example.newsfeed.follow.repository.FollowRepository;
 import com.example.newsfeed.user.application.service.UserService;
 import com.example.newsfeed.user.entity.User;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,6 +15,7 @@ import java.util.List;
 
 import static com.example.newsfeed.global.common.exception.ErrorCode.*;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class FollowService {
@@ -23,7 +25,6 @@ public class FollowService {
     
     @Transactional
     public boolean toggleFollow(Long sessionUserId, Long targetUserId) {
-
         if(sessionUserId.equals(targetUserId)) { // 자기 자신을 팔로우 시도 하면 발생 -> 현재 500번 에러 발생
             throw new CannotFollowSelfException(List.of(
                   new ErrorDetail(CANNOT_FOLLOW_SELF,null, CANNOT_FOLLOW_SELF.getMessage())
@@ -32,8 +33,9 @@ public class FollowService {
 
         User follower = userService.findUserById(sessionUserId);
         User following = userService.findUserById(targetUserId);
-
-        return followRepository.findByFollowerAndFollowing(follower, following)
+        log.info("Before Follow Count - Follower: {}, Following: {}",
+                follower.getFollowingsCount(), following.getFollowersCount());
+        Boolean isFollowing = followRepository.findByFollowerAndFollowing(follower, following)
                 // A유저가  B유저를 팔로잉 하는 상황
                 .map(existingFollow -> { // A유저 팔로잉 리스트에 이미 B가 존재한다면
                     follower.decreaseFollowings(); // A의 팔로잉 수 -1
@@ -51,6 +53,9 @@ public class FollowService {
                     followRepository.save(follow);
                     return true; // 팔로우 처리
                 });
+        log.info("After Follow Count - Follower: {}, Following: {}",
+                follower.getFollowingsCount(), following.getFollowersCount());
+        return isFollowing;
     }
     // 특정 사용자가 팔로우한 ID 목록 조회
     @Transactional(readOnly = true)

--- a/src/main/java/com/example/newsfeed/follow/controller/FollowController.java
+++ b/src/main/java/com/example/newsfeed/follow/controller/FollowController.java
@@ -1,9 +1,8 @@
 package com.example.newsfeed.follow.controller;
 
-import com.example.newsfeed.global.common.Const.SessionConst;
-import com.example.newsfeed.global.response.Response;
 import com.example.newsfeed.follow.application.service.FollowService;
-import jakarta.servlet.http.HttpSession;
+import com.example.newsfeed.global.common.constant.SessionConst;
+import com.example.newsfeed.global.response.Response;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/com/example/newsfeed/follow/entity/Follow.java
+++ b/src/main/java/com/example/newsfeed/follow/entity/Follow.java
@@ -14,7 +14,8 @@ import java.time.LocalDateTime;
 @Getter
 @Entity
 @EntityListeners(AuditingEntityListener.class)
-@Table(name = "follows")
+@Table(name = "follows",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"follower_id, following_id"}))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Follow {
 

--- a/src/main/java/com/example/newsfeed/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/newsfeed/global/common/exception/ErrorCode.java
@@ -34,6 +34,7 @@ public enum ErrorCode {
 
     // 파일 관련 예외 코드
     UPLOAD_FAILED("파일 업로드에 실패했습니다.", INTERNAL_SERVER_ERROR),
+    UN_SUPPORTED_FILE_TYPE("지원하지 않는 파일 타입입니다.", BAD_REQUEST),
     FILE_NOT_FOUND("파일을 찾을 수 없습니다.", NOT_FOUND),
 
 

--- a/src/main/java/com/example/newsfeed/global/common/file/FileType.java
+++ b/src/main/java/com/example/newsfeed/global/common/file/FileType.java
@@ -1,7 +1,15 @@
 package com.example.newsfeed.global.common.file;
 
+import com.example.newsfeed.global.common.exception.ErrorDetail;
+import com.example.newsfeed.global.common.file.exception.UnSupportedFileTypeException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+import static com.example.newsfeed.global.common.constant.ImageUrlConst.DEFAULT_PROFILE_IMAGE_PATH;
+import static com.example.newsfeed.global.common.exception.ErrorCode.UN_SUPPORTED_FILE_TYPE;
 
 @Getter
 @RequiredArgsConstructor
@@ -12,4 +20,22 @@ public enum FileType {
     DEFAULT("default");
 
     private final String type;
+
+    public static FileType from(String type) {
+        for (FileType fileType : values()) {
+            if (fileType.type.equalsIgnoreCase(type)) {
+                return fileType;
+            }
+        }
+        throw new UnSupportedFileTypeException(List.of(
+            new ErrorDetail(UN_SUPPORTED_FILE_TYPE, "type", UN_SUPPORTED_FILE_TYPE.getMessage())
+        ));
+    }
+
+    public String resolveSubDirectory(MultipartFile file, String defaultProFileImagePath) {
+        if (this == DEFAULT && (file == null || file.isEmpty())) {
+            return defaultProFileImagePath;
+        }
+        return this.getType();
+    }
 }

--- a/src/main/java/com/example/newsfeed/global/common/file/exception/UnSupportedFileTypeException.java
+++ b/src/main/java/com/example/newsfeed/global/common/file/exception/UnSupportedFileTypeException.java
@@ -1,0 +1,13 @@
+package com.example.newsfeed.global.common.file.exception;
+
+import com.example.newsfeed.global.common.exception.BaseException;
+import com.example.newsfeed.global.common.exception.ErrorDetail;
+
+import java.util.List;
+
+public class UnSupportedFileTypeException extends BaseException {
+
+    public UnSupportedFileTypeException(List<ErrorDetail> errorDetails) {
+        super(errorDetails);
+    }
+}

--- a/src/main/java/com/example/newsfeed/global/common/file/service/LocalFileService.java
+++ b/src/main/java/com/example/newsfeed/global/common/file/service/LocalFileService.java
@@ -1,6 +1,7 @@
 package com.example.newsfeed.global.common.file.service;
 
 import com.example.newsfeed.global.common.exception.ErrorDetail;
+import com.example.newsfeed.global.common.file.FileType;
 import com.example.newsfeed.global.common.file.exception.FileUploadFailedException;
 import com.example.newsfeed.user.application.service.UserService;
 import com.example.newsfeed.user.entity.User;
@@ -23,7 +24,7 @@ import java.util.UUID;
 
 import static com.example.newsfeed.global.common.constant.ImageUrlConst.DEFAULT_PROFILE_IMAGE_PATH;
 import static com.example.newsfeed.global.common.exception.ErrorCode.UPLOAD_FAILED;
-import static com.example.newsfeed.global.common.file.FileType.*;
+import static com.example.newsfeed.global.common.file.FileType.from;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 @Service
@@ -39,23 +40,14 @@ public class LocalFileService implements FileService {
     public String uploadImage(String type, MultipartFile file, Long sessionUserId) {
         User getSessionUser = userService.findUserById(sessionUserId);
 
-        // 프로필 이미지를 기본 이미지로 변경
-        if (DEFAULT.getType().equalsIgnoreCase(type) && file.isEmpty()) {
-            return DEFAULT_PROFILE_IMAGE_PATH;
-        }
+        // 업로드하는 타입에 따라 하위 폴더명 설정
+        FileType fileType = from(type);
+
+        // 기본 이미지 변경 요청일 경우, 파일 업로드 없이 바로 기본 프로필 이미지 경로 반환
+        String subDirectory = fileType.resolveSubDirectory(file, DEFAULT_PROFILE_IMAGE_PATH);
 
         // 이메일 암호화
         String convertEmail = DigestUtils.md5DigestAsHex(getSessionUser.getEmail().getBytes());
-
-        // 업로드하는 타입에 따라 하위 폴더명 설정
-        String subDirectory;
-        if (PROFILE.getType().equalsIgnoreCase(type)) {
-            subDirectory = "profile";
-        } else if (FEEDS.getType().equalsIgnoreCase(type)) {
-            subDirectory = "feeds";
-        } else {
-            subDirectory = "others";
-        }
 
         // 업로드하는 시간을 가져와서 연/월/일로 변환
         String datePath = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy/MM/dd"));
@@ -77,7 +69,7 @@ public class LocalFileService implements FileService {
 
             // uploadPath에 fileName을 더한 최종 경로를 반환
             Path filePath = uploadPath.resolve(fileName);
-            
+
             // file.getInputStream()으로 읽은 뒤 filePath에 동일한 파일이 있을 경우 덮어쓰기 후 저장
             Files.copy(file.getInputStream(), filePath, REPLACE_EXISTING);
 

--- a/src/main/java/com/example/newsfeed/like/controller/LikeController.java
+++ b/src/main/java/com/example/newsfeed/like/controller/LikeController.java
@@ -1,6 +1,6 @@
 package com.example.newsfeed.like.controller;
 
-import com.example.newsfeed.global.common.Const.SessionConst;
+import com.example.newsfeed.global.common.constant.SessionConst;
 import com.example.newsfeed.global.response.Response;
 import com.example.newsfeed.like.application.service.LikeService;
 import com.example.newsfeed.like.dto.LikeResponseDto;

--- a/src/main/java/com/example/newsfeed/like/entity/Like.java
+++ b/src/main/java/com/example/newsfeed/like/entity/Like.java
@@ -10,7 +10,8 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "likes", uniqueConstraints = @UniqueConstraint(columnNames = {"user_id","feed_id"}))
+@Table(name = "likes",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"user_id","feed_id"}))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Like {
     @Id

--- a/src/main/java/com/example/newsfeed/user/entity/User.java
+++ b/src/main/java/com/example/newsfeed/user/entity/User.java
@@ -41,10 +41,11 @@ public class User extends BaseTimeEntity {
     private LocalDateTime deletedAt;
 
     @Builder
-    public User(String email, String password, String name) {
+    public User(String email, String password, String name, String profileImage) {
         this.email = email;
         this.password = password;
         this.name = name;
+        this.profileImage = profileImage;
     }
 
     public void updatePassword(String password) {


### PR DESCRIPTION
## 📌 What is this PR ?
회원가입 시 기본 이미지까지 저장되도록 수정

<br/>

## 🔎 Additions
- 회원가입 시 `ImageUrlConst.DEFAULT_PROFILE_IMAGE_PATH` 값을 저장하도록 수정하고 `User` 엔티티 내 생성자에 profileImage 값을 받을 수 있도록 추가
- type 값에 맞는 `FileType`을 찾을 수 없을 경우를 위해 `UnSupportedFileTypeException` 와  `ErrorCode.UN_SUPPORTED_FILE_TYPE` 정의

## 🔎 Changes
- subDirectory 이름을 정하는 메서드의 재사용성과 응집도를 높이기 위해 `FileType`으로 옮김
- 로그인 시 사용하는 `findByEmail()`을 soft-delete 된 사용자를 제외하고 찾기 위해 `findUserByEmailAndDeletedAtIsNull()`로 수정하고 JPQL 추가

<br/>

## ✅ Test Checklist
- [X] PR 양식에 맞춰서 작성했나요?
- [X] Reviewers를 등록했나요?
- [X] Assignees를 등록했나요?
- [X] Labels를 등록했나요?
